### PR TITLE
Add Worktree GitHub Action for one-click issue workspaces

### DIFF
--- a/.github/workflows/worktree.yml
+++ b/.github/workflows/worktree.yml
@@ -1,0 +1,11 @@
+name: Worktree
+on:
+  issues:
+    types: [opened]
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: worktree-io/comment-action@v1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ docs/            In-depth research and design documentation
 logs/            Generated session reports (gitignored)
 ```
 
+## Worktree Integration
+
+New issues automatically receive an "Open workspace" comment link via the [Worktree](https://worktree.io/) GitHub Action. Clicking it creates an isolated git worktree on your local machine and opens it in your editor.
+
+To use this, install the Worktree daemon locally:
+
+```bash
+cargo install worktree-io
+worktree setup
+```
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.github/workflows/worktree.yml` that posts an "Open workspace" comment on every new issue via the [Worktree](https://worktree.io/) GitHub Action
- Document local Worktree daemon setup in README

Closes #5

## Test plan
- [ ] Open a new issue and verify the Worktree bot comments with a workspace link
- [ ] Confirm the workflow only triggers on `issues: opened` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)