### PR TITLE
fix: repair release workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
             cross: true
             archive: tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             cross: false
             archive: tar.gz
           - target: aarch64-apple-darwin
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install cross (Linux ARM)
         if: matrix.cross
-        run: cargo install cross --tag v0.2.5
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build
         if: "!matrix.cross"
@@ -212,7 +212,7 @@ jobs:
             cross: true
             archive: tar.gz
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             cross: false
             archive: tar.gz
           - target: aarch64-apple-darwin
@@ -243,7 +243,7 @@ jobs:
 
       - name: Install cross (Linux ARM)
         if: matrix.cross
-        run: cargo install cross --tag v0.2.5
+        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
 
       - name: Build
         if: "!matrix.cross"

--- a/council-daemon/src/server.rs
+++ b/council-daemon/src/server.rs
@@ -125,6 +125,7 @@ impl CouncilService {
     }
 }
 
+#[allow(clippy::result_large_err)] // Status is from tonic; boxing would complicate all call sites
 fn validate_token(session: &Session, name: &str, token: &str) -> Result<(), Status> {
     match session.participants.iter().find(|p| p.name == name) {
         Some(p) if p.token == token => Ok(()),


### PR DESCRIPTION
## Summary
- **cross install broken**: `cargo install cross --tag v0.2.5` fails because modern Cargo requires `--git <URL>` when using `--tag`. Added the `--git https://github.com/cross-rs/cross` flag to both daemon and CLI build matrices.
- **Clippy `result_large_err`**: `validate_token` returns `Result<(), tonic::Status>` which is 176 bytes. Added a targeted `#[allow(clippy::result_large_err)]` since `Status` is from an external crate and boxing would complicate all call sites.
- **`macos-13` runner unavailable**: GitHub deprecated Intel macOS runners. Changed `x86_64-apple-darwin` builds to use `macos-latest` (arm64) with Rust's cross-compilation support.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes locally
- [ ] CI workflow (clippy, fmt, tests) passes on PR
- [ ] Release workflow builds succeed for all targets including `aarch64-unknown-linux-gnu` and `x86_64-apple-darwin`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)