### PR TITLE
fix: install protoc in cross container for aarch64-linux builds

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update && apt-get install -y protobuf-compiler",
+]


### PR DESCRIPTION
## Summary
- Adds `Cross.toml` with `pre-build` hook to install `protobuf-compiler` inside the cross Docker container
- Fixes the remaining `aarch64-unknown-linux-gnu` build failure where `protoc` was not found during compilation (`council-proto` requires it for `tonic_build`)
- Deletes the orphaned `council-daemon/v1.0.1` tag (had no release) so the version calculation re-derives it after merge

## Context
PR #27 fixed the `cross` install command, clippy error, and `macos-13` runner. After merge, the `aarch64-unknown-linux-gnu` daemon build still failed because `arduino/setup-protoc` only installs on the host, not inside the cross Docker container.

## Test plan
- [ ] CI passes (clippy, fmt, tests)
- [ ] After merge, release workflow succeeds for all targets including `aarch64-unknown-linux-gnu`

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)