### PR TITLE
feat!: release 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "council-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "council-proto",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "council-daemon"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "clap",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "council-proto"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "prost",
  "tonic",

--- a/council-cli/Cargo.toml
+++ b/council-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "council-cli"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/nabi-allenby/council"
@@ -15,7 +15,7 @@ name = "council-cli"
 path = "src/main.rs"
 
 [dependencies]
-council-proto = { path = "../council-proto", version = "0.1.0" }
+council-proto = { path = "../council-proto", version = "1.0.0" }
 tonic = "0.12"
 prost = "0.13"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "time"] }

--- a/council-daemon/Cargo.toml
+++ b/council-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "council-daemon"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/nabi-allenby/council"
@@ -15,7 +15,7 @@ name = "council-daemon"
 path = "src/main.rs"
 
 [dependencies]
-council-proto = { path = "../council-proto", version = "0.1.0" }
+council-proto = { path = "../council-proto", version = "1.0.0" }
 tonic = "0.12"
 prost = "0.13"
 tokio = { version = "1", features = ["full"] }

--- a/council-proto/Cargo.toml
+++ b/council-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "council-proto"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/nabi-allenby/council"


### PR DESCRIPTION
## Summary

- Bump all crate versions (`council-proto`, `council-daemon`, `council-cli`) from `0.1.0` to `1.0.0`
- Marks the first stable release of the Council deliberation system

## Council 1.0.0 — Feature Summary

**Council** is a turn-based deliberation system where AI agents with distinct personalities discuss a question across multiple rounds, then cast binding votes.

### Core Features

- **Multi-agent deliberation framework** — turn-based rotation with 1–7 agents, configurable rounds, and structured discussion lifecycle (lobby → discussion → voting → results)
- **Dual backend support** — Anthropic Messages API (default, requires `ANTHROPIC_API_KEY`) and Claude Agent SDK (uses Claude CLI, no key needed)
- **Agent personality system** — five built-in roles (Architect, Sentinel, Steward, Mediator, Firebrand) with customisable `.md` personality files
- **gRPC microservice architecture** — `council-daemon` orchestrates sessions, `council-cli` participates; 8 RPC operations (CreateSession, Join, Wait, Respond, Vote, Results, etc.)
- **Multi-session management** — up to 10 concurrent sessions with LRU eviction, unique session IDs, and participant token auth
- **Motion-crafting stage** — agents collaboratively frame the question before deliberation begins
- **Parallel agent calls** — agents within a round are called concurrently for faster throughput
- **HTTP retry with backoff** — resilient API calls with automatic rate-limit handling
- **Structured output & reporting** — full markdown decision records, vote breakdowns, and session transcripts
- **Automatic daemon setup** — `council-daemon setup` bootstraps config at `~/.config/council/config.toml` with hook script orchestration
- **Cross-platform CI/CD** — builds for Linux (x86_64/aarch64), macOS (x86_64/arm64), and Windows; publishes to crates.io and GitHub Releases

Closes #30

## Test plan

- [x] `cargo check` passes for all workspace crates
- [ ] CI passes (fmt, clippy, tests)
- [ ] Release workflow creates `council-daemon/v1.0.0` and `council-cli/v1.0.0` tags on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)